### PR TITLE
fix: add datepicker light mode text coloring

### DIFF
--- a/src/lib/datepicker/theme.ts
+++ b/src/lib/datepicker/theme.ts
@@ -4,7 +4,7 @@ export const datepicker = tv({
   slots: {
     base: "inline-block rounded-lg bg-white dark:bg-gray-700 shadow-lg p-4",
     input: "w-full rounded-md border px-4 py-2 text-sm focus:ring-2 focus:outline-none outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white",
-    titleVariant: "mb-2 text-lg font-semibold dark:text-white",
+    titleVariant: "mb-2 text-lg font-semibold text-gray-900 dark:text-white",
     polite: "text-sm rounded-lg text-gray-900 dark:text-white bg-white dark:bg-gray-700 font-semibold py-2.5 px-5 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-200",
     button: "absolute inset-y-0 right-0 flex items-center px-3 text-gray-500 focus:outline-hidden dark:text-gray-400",
     actionButtons: "mt-4 flex justify-between",


### PR DESCRIPTION
This pull request includes a small change to the `src/lib/datepicker/theme.ts` file. The change modifies the `titleVariant` slot to ensure consistent text color across different themes.

* [`src/lib/datepicker/theme.ts`](diffhunk://#diff-7ab1ba261c54d4af5608504449d67f360503e21f9cead5681fe559581836db9dL7-R7): Updated the `titleVariant` slot to use `text-gray-900` for light mode to ensure consistent text color.

Prior there would be an issue where light-mode could periodically display white text on top of a white background, this fixes the theming issues so that it now correctly displays the gray-900 text on top of a white background.